### PR TITLE
Remove tail if the end is reached

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,10 +47,12 @@ export class Bin {
 			} else if ("Destroy" in item) {
 				item.Destroy();
 			}
-		
-			if (this.head === this.tail) this.tail = undefined;
+
 			this.head = this.head.next;
 		}
+
+		// list is now empty, so we can clear the tail
+		this.tail = undefined;
 	}
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,8 @@ export class Bin {
 			} else if ("Destroy" in item) {
 				item.Destroy();
 			}
+		
+			if (this.head === this.tail) this.tail = undefined;
 			this.head = this.head.next;
 		}
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,6 @@ export class Bin {
 			} else if ("Destroy" in item) {
 				item.Destroy();
 			}
-
 			this.head = this.head.next;
 		}
 


### PR DESCRIPTION
Currently the tail will still hold a reference to the last value even if it the bin was destroyed. I think it would be better if that were not the case.

I'd be in favor of removing tail completely, but I think a lot of people would appreciate that the order of destruction matches the order of addition.