### PR TITLE
Support disconnect/Disconnect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export namespace Bin {
-	export type Item = (() => unknown) | RBXScriptConnection | thread | { destroy(): void } | { Destroy(): void };
+	export type Item = (() => unknown) | RBXScriptConnection | thread | { destroy(): void } | { Destroy(): void } | { disconnect(): void } | { Disconnect(): void };
 }
 
 type Node = { next?: Node; item: Bin.Item };
@@ -46,6 +46,10 @@ export class Bin {
 				item.destroy();
 			} else if ("Destroy" in item) {
 				item.Destroy();
+			} else if ("disconnect" in item) {
+				item.disconnect();
+			} else if ("Disconnect" in item) {
+				item.Disconnect();
 			}
 			this.head = this.head.next;
 		}


### PR DESCRIPTION
The TypeScript types allow anything that looks like an `RBXScriptConnection` to count as binnable, including custom signal connections. This led me to erroneously believe this would disconnect them just as nicely as an actual `RBXScriptConnection`. I'd like to suggest `(d/D)isconnect` be treated like `(d/D)estroy`.